### PR TITLE
Clarify tutorial explanation of First Strike

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -330,7 +330,7 @@ A detailed explanation of healing may be found in the <i>Gameplay</i> section of
             speaker=narrator
             caption= _ "Weapon Specials"
             image=wesnoth-icon.png
-            message= _ "Weapon specials are special attack modifiers that make certain attacks more powerful. In this case, the Shaman has the Slows special on her entangle attack. When this attack successfully hits an enemy, it will halve the damage they do for one turn. Other weapon specials include First Strike, which allows that attack to always hit first no matter who attacks first, and Magical, which gives that attack a constant 70% chance to hit.
+            message= _ "Weapon specials are special attack modifiers that make certain attacks more powerful. In this case, the Shaman has the Slows special on her entangle attack. When this attack successfully hits an enemy, it will halve the damage they do for one turn. Other weapon specials include First Strike, which allows that attack to always hit first no matter who initiates combat, and Magical, which gives that attack a constant 70% chance to hit.
 
 A full list of abilities and weapons specials, along with traits, may be found in the help (default hotkey: <b>F1</b>)."
         [/message]


### PR DESCRIPTION
The current tutorial uses "attack" twice in the same sentence to refer to two separate concepts: an offensive ability inherent to a unit, and using such an offensive ability on an enemy unit, and it uses the phrases "hits first" and "attacks first" alongside. This can be confusing to new players, who may not yet understand the two different connotations of "attack" being used, or to whom the words "hit" and "attack" appear synonymous.