### PR TITLE
Clarify Elven Hero sword attack damage

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -1402,7 +1402,7 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
 
         [message]
             speaker=unit
-            message= _ "Advancing a level has fully healed me! I am particularly good with the sword, dealing 8 damage in 4 attacks. While I don’t have the Leadership abilities of the Elvish Captain, my superior fighting skills allow my attacks to do more damage!"
+            message= _ "Advancing a level has fully healed me! I am particularly good with the sword, attacking 4 times for 8 damage each. While I don’t have the Leadership abilities of the Elvish Captain, my superior fighting skills allow my attacks to do more damage!"
         [/message]
     [/event]
 


### PR DESCRIPTION
To a player not paying attention, "8 damage in 4 attacks" could be taken to mean 4 attacks dealing 2 damage each, which is misleading.